### PR TITLE
[WEAV-58] DaysNextButton

### DIFF
--- a/3days/app/src/main/AndroidManifest.xml
+++ b/3days/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme._3days">
+            android:theme="@style/Theme._3days"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/3days/core/design-system/src/main/java/com/weave/design_system/component/DaysNextButton.kt
+++ b/3days/core/design-system/src/main/java/com/weave/design_system/component/DaysNextButton.kt
@@ -1,0 +1,111 @@
+package com.weave.design_system.component
+
+import android.util.Log
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.weave.design_system.DaysTheme
+
+enum class BtnType {
+    Tall, Short
+}
+
+@Composable
+fun DaysNextButton(
+    modifier: Modifier = Modifier,
+    message: String = "다음",
+    type: BtnType = BtnType.Tall,
+    isEnabled: Boolean = false,
+    onClick: () -> Unit
+) {
+    Log.i("Keyboard", type.toString())
+
+    val buttonHeight = when (type) {
+        BtnType.Tall -> 90.dp
+        BtnType.Short -> 68.dp
+    }
+
+    Button(
+        onClick = onClick,
+        enabled = isEnabled,
+        shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
+        colors = ButtonColors(
+            containerColor = DaysTheme.colors.grey500,
+            contentColor = DaysTheme.colors.white,
+            disabledContainerColor = DaysTheme.colors.grey100,
+            disabledContentColor = DaysTheme.colors.white,
+        ),
+        modifier = modifier
+            .fillMaxWidth()
+            .height(buttonHeight)
+    ) {
+        Text(
+            text = message,
+            style = DaysTheme.typography.semiBold18.toTextStyle(),
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+//@Composable
+//fun SampleCode(){
+//    val context = LocalContext.current
+//
+//    var inputText by remember { mutableStateOf("") }
+//    val isEnabled = inputText.length >= 2
+//
+//    val keyboardController = LocalSoftwareKeyboardController.current
+//    val isKeyboardVisible by keyboardAsState()
+//    val buttonType = if (isKeyboardVisible == Keyboard.Opened) BtnType.Short else BtnType.Tall
+//
+//    DaysTheme {
+//        Box(
+//            modifier = Modifier
+//                .fillMaxSize()
+//                .imePadding()
+//        ) {
+//            Column(
+//                modifier = Modifier
+//                    .fillMaxWidth()
+//                    .padding(16.dp),
+//                horizontalAlignment = Alignment.CenterHorizontally,
+//                verticalArrangement = Arrangement.Center
+//            ) {
+//                TextField(
+//                    value = inputText,
+//                    onValueChange = { newText ->
+//                        inputText = newText
+//                    },
+//                    label = { Text("Enter Text") },
+//                    modifier = Modifier.fillMaxWidth(),
+//                    singleLine = true,
+//                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+//                    keyboardActions = KeyboardActions(
+//                        onDone = { keyboardController?.hide() }),
+//                )
+//
+//                Spacer(modifier = Modifier.height(16.dp))
+//            }
+//
+//            DaysNextButton(
+//                message = "다음",
+//                type = buttonType,
+//                isEnabled = isEnabled,
+//                onClick = {
+//                    if (isEnabled) {
+//                        Toast.makeText(context, "성공", Toast.LENGTH_SHORT).show()
+//                    }
+//                },
+//                modifier = Modifier
+//                    .align(Alignment.BottomCenter)
+//            )
+//        }
+//    }
+//}

--- a/3days/core/utils/build.gradle.kts
+++ b/3days/core/utils/build.gradle.kts
@@ -18,6 +18,12 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString()
     }
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.14"
+    }
 }
 
 dependencies {

--- a/3days/core/utils/src/main/java/com/weave/utils/SoftKeyboardObserver.kt
+++ b/3days/core/utils/src/main/java/com/weave/utils/SoftKeyboardObserver.kt
@@ -1,0 +1,40 @@
+package com.weave.utils
+
+import android.graphics.Rect
+import android.view.ViewTreeObserver
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalView
+
+enum class Keyboard {
+    Opened, Closed
+}
+
+@Composable
+fun keyboardAsState(): State<Keyboard> {
+    val keyboardState = remember { mutableStateOf(Keyboard.Closed) }
+    val view = LocalView.current
+    DisposableEffect(view) {
+        val onGlobalListener = ViewTreeObserver.OnGlobalLayoutListener {
+            val rect = Rect()
+            view.getWindowVisibleDisplayFrame(rect)
+            val screenHeight = view.rootView.height
+            val keypadHeight = screenHeight - rect.bottom
+            keyboardState.value = if (keypadHeight > screenHeight * 0.15) {
+                Keyboard.Opened
+            } else {
+                Keyboard.Closed
+            }
+        }
+        view.viewTreeObserver.addOnGlobalLayoutListener(onGlobalListener)
+
+        onDispose {
+            view.viewTreeObserver.removeOnGlobalLayoutListener(onGlobalListener)
+        }
+    }
+
+    return keyboardState
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- `MainActivity`의 소프트 키보드 표시 시 창 크기 조정 방식 변경.
	- 사용자 정의 가능한 `DaysNextButton` 버튼 추가, 두 가지 유형(Tall, Short) 지원.
	- 소프트 키보드 상태를 관찰하는 `keyboardAsState()` 함수 추가.

- **버그 수정**
	- Jetpack Compose 지원을 위한 빌드 구성 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->